### PR TITLE
Updated php74 tap to php@7.4

### DIFF
--- a/src/mac/install.sh
+++ b/src/mac/install.sh
@@ -61,7 +61,7 @@ if [ "$PHP_INSTALL" == "1" ]; then
     brew tap homebrew/dupes
     brew tap homebrew/versions
     brew tap homebrew/homebrew-php
-    brew install php74
+    brew install php@7.4
 fi
 
 if [ "$COMPOSER_INSTALL" == "1" ]; then


### PR DESCRIPTION
It was changed recently. This was brew's error message: 

`homebrew/php was deprecated. This tap is now empty as all its formulae were migrated.`